### PR TITLE
ci(dev): deploy backend to k3s over Tailscale instead of EC2

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -88,20 +88,37 @@ jobs:
             stephyborrego/brew-and-co-backend:${{ github.sha }}
 
   deploy-dev:
-    name: Deploy to Dev
+    name: Deploy to Dev (k3s)
     runs-on: ubuntu-latest
     needs: docker
     if: github.ref == 'refs/heads/dev' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
 
     steps:
-      - name: Deploy to EC2 Dev
-        uses: appleboy/ssh-action@v1.0.3
+      # The dev node is a private k3s box with no public IP; reach it over Tailscale.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
         with:
-          host: ${{ secrets.EC2_DEV_HOST }}
-          username: ec2-user
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            docker pull stephyborrego/brew-and-co-backend:latest && docker stop brew-and-co-backend || true && docker rm brew-and-co-backend || true && docker run -d -p 3000:3000 -e PORT=3000 -e NODE_ENV=development -e SENTRY_DSN=${{ secrets.SENTRY_DSN }} -e MONGODB_URI="${{ secrets.MONGODB_URI }}" -e JWT_SECRET="${{ secrets.JWT_SECRET }}" -e CORS_ORIGIN="${{ secrets.CORS_ORIGIN_DEV }}" --name brew-and-co-backend --restart always stephyborrego/brew-and-co-backend:latest
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Write kubeconfig
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          printf '%s' "$KUBE_CONFIG_B64" | base64 -d > "$RUNNER_TEMP/kubeconfig"
+          chmod 600 "$RUNNER_TEMP/kubeconfig"
+
+      - name: Roll out new image
+        env:
+          KUBECONFIG: ${{ runner.temp }}/kubeconfig
+        run: |
+          kubectl -n brew-and-co set image deployment/brew-and-co-backend \
+            backend=stephyborrego/brew-and-co-backend:${{ github.sha }}
+          kubectl -n brew-and-co rollout status deployment/brew-and-co-backend --timeout=120s
 
   deploy-prod:
     name: Deploy to Prod

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.tfstate.*
 .terraform/
 .terraform.lock.hcl
+
+# Kubernetes secrets — real values only; use k8s/**/secret.example.yaml as the template
+k8s/**/secret.yaml

--- a/k8s/dev/deployment.yaml
+++ b/k8s/dev/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: brew-and-co-backend
+  namespace: brew-and-co
+  labels:
+    app: brew-and-co-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: brew-and-co-backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: brew-and-co-backend
+    spec:
+      containers:
+        - name: backend
+          # CI overrides this with :<git sha> via `kubectl set image`.
+          image: stephyborrego/brew-and-co-backend:latest
+          ports:
+            - name: http
+              containerPort: 3000
+          # All config comes from the brew-and-co-backend-env Secret
+          # (see secret.example.yaml). Nothing sensitive is hardcoded here.
+          envFrom:
+            - secretRef:
+                name: brew-and-co-backend-env
+          resources:
+            # Starting point for an Intel dual-core node with limited RAM.
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/k8s/dev/namespace.yaml
+++ b/k8s/dev/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: brew-and-co

--- a/k8s/dev/secret.example.yaml
+++ b/k8s/dev/secret.example.yaml
@@ -1,0 +1,21 @@
+# Template for the backend config Secret. Copy to secret.yaml, fill in real
+# values, and apply it once to the cluster:
+#
+#   cp k8s/dev/secret.example.yaml k8s/dev/secret.yaml
+#   # edit k8s/dev/secret.yaml
+#   kubectl apply -f k8s/dev/secret.yaml
+#
+# secret.yaml is git-ignored - never commit real values.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: brew-and-co-backend-env
+  namespace: brew-and-co
+type: Opaque
+stringData:
+  PORT: "3000"
+  NODE_ENV: "development"
+  MONGODB_URI: "mongodb+srv://USER:PASSWORD@cluster0.xxxxx.mongodb.net/brewandco?retryWrites=true&w=majority"
+  JWT_SECRET: "replace-with-a-long-random-string"
+  CORS_ORIGIN: "https://brew-and-co-dev.pages.dev"
+  SENTRY_DSN: ""

--- a/k8s/dev/service.yaml
+++ b/k8s/dev/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: brew-and-co-backend
+  namespace: brew-and-co
+  labels:
+    app: brew-and-co-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: brew-and-co-backend
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http


### PR DESCRIPTION
- deploy-dev: replace SSH+docker run with tailscale/github-action, then kubectl set image + rollout status (--timeout=120s) against KUBE_CONFIG
- drop EC2_DEV_HOST / dev SSH deploy; deploy-prod still on EC2, untouched
- add k8s/dev manifests: namespace, deployment (1 replica, 128Mi/100m requests, 256Mi/250m limits, /health probes), ClusterIP service, and secret.example.yaml for the backend env Secret
- gitignore k8s/**/secret.yaml