### PR TITLE
fix: exclude k8s secrets from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.tfstate.*
 .terraform/
 .terraform.lock.hcl
+k8s/**/secret.yaml


### PR DESCRIPTION
Adds k8s/**/secret.yaml to .gitignore to prevent committing real credentials.